### PR TITLE
マイページのビューを一部作成編集及び、コントローラー作成、ルーティング追加。

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,2 @@
 @import "reset";
-
+@import "users/show";

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/users/_show.scss
+++ b/app/assets/stylesheets/users/_show.scss
@@ -36,6 +36,7 @@
     margin: 40px 40px 0 40px;
     .Main {
       background-color: #fff;
+      min-width: 200px;
       &__head {
         padding: 19px;
         border-bottom: 1px solid #f5f5f5;
@@ -47,6 +48,10 @@
         padding: 0 64px 20px;
         &__group {
           margin: 40px 0 0;
+          &__item {
+            padding: 10px 0 0 0;
+            word-break: break-all;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/users/_show.scss
+++ b/app/assets/stylesheets/users/_show.scss
@@ -1,0 +1,54 @@
+* {
+  box-sizing: border-box;
+}
+
+.Container {
+  background-color: #EEEEEE;
+  display: flex;
+  height: 100vh;
+  // margin: 40px 0;
+  width: 100%;
+  .Mypage-side {
+    width: 300px;
+    margin: 40px;
+    .Mypage__nav {
+      background-color: #fff;
+      &__list {
+        &__li {
+          border-bottom: 1px solid #eeeeee;
+          width: 100%;
+          & > a {
+            display: block;
+            width: 100%;
+            padding: 20px;
+          }
+          &:hover {
+            text-decoration: underline;
+            color: red;
+          }
+        }
+      }
+    }
+  }
+    // ここからメイン
+  .Mypage-main {
+    width: calc( 100vw - 300px );
+    margin: 40px 40px 0 40px;
+    .Main {
+      background-color: #fff;
+      &__head {
+        padding: 19px;
+        border-bottom: 1px solid #f5f5f5;
+        text-align: center;
+        font-size: 18px;
+        font-weight: bold;
+      }
+      &__information {
+        padding: 0 64px 20px;
+        &__group {
+          margin: 40px 0 0;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def show
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/users/_mypage_main.html.haml
+++ b/app/views/users/_mypage_main.html.haml
@@ -7,7 +7,7 @@
         %p.Main__information__group__item 
           山田太郎 
       %li.Main__information__group
-        お名前カナ 
+        フリガナ 
         %p.Main__information__group__item 
           ヤマダ タロウ 
       %li.Main__information__group 

--- a/app/views/users/_mypage_main.html.haml
+++ b/app/views/users/_mypage_main.html.haml
@@ -1,0 +1,20 @@
+.Mypage-main
+  %section.Main
+    %h2.Main__head 本人登録情報
+    %ul.Main__information
+      %li.Main__information__group 
+        お名前 
+        %p.Main__information__group__item 
+          山田太郎 
+      %li.Main__information__group
+        お名前カナ 
+        %p.Main__information__group__item 
+          ヤマダ タロウ 
+      %li.Main__information__group 
+        生年月日 
+        %p.Main__information__group__item 
+          1986/11/11
+      %li.Main__information__group 
+        e-mail 
+        %p.Main__information__group__item 
+          yamada@yamada.com 

--- a/app/views/users/_mypage_side.html.haml
+++ b/app/views/users/_mypage_side.html.haml
@@ -1,0 +1,7 @@
+.Mypage-side
+  %nav.Mypage__nav
+    %ul.Mypage__nav__list
+      %li.Mypage__nav__list__li= link_to 'プロフィール', class: "List__item"
+      %li.Mypage__nav__list__li= link_to '本人登録情報', class: "List__item"
+      %li.Mypage__nav__list__li= link_to 'クレジット登録/編集', class: "List__item"
+      %li.Mypage__nav__list__li= link_to 'ログアウト', class: "List__item"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,3 @@
+.Container
+  = render "mypage_side"
+  = render "mypage_main"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root 'items#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :users, only: :show
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
マイページのビューを一部作成編集及び、コントローラー作成、ルーティング追加。以下詳細手順

①usersコントローラー作成→showアクション定義
②usersコントローラーのshowアクションをルーティングに追加。
③Mypage関連のビューを作成、編集（合計３枚）。
④assets/usersフォルダ作成し、_show.scssファイルを作成、編集し。（application.scss）に読み込み追記。

※マイページのビューに関しては現状必要最低限のみとし、今後サーバーサイドを実装する際に、対象となる機能を実装する人が、追加でページの編集を行っていくこととした。

# Why
マイページで、プロフィール、本人登録情報、クレジット登録/編集、ログアウトなどを確認編集できるようにする為。


![05091bc5fa2925d8b326aca700a748aa](https://user-images.githubusercontent.com/68668379/95656559-27506e00-0b4a-11eb-8556-b7e3117751a1.gif)


