### PR TITLE
ユーザー登録画面のサーバーサイド実装とアドレステーブルの作成

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,9 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  private
+  protected
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
 
@@ -13,5 +14,8 @@ class ApplicationController < ActionController::Base
   def production?
     Rails.env.production?
   end
-  
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :firstname, :lastname, :firstname_kana, :lastname_kana, :birth])
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,29 @@
 class UsersController < ApplicationController
+  before_action :move_to_index, except: [:index, :show]
+
+  def new
+  end
+  
+  def create
+    if current_user.create(user_params)
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
   def show
+  end
+
+  def move_to_index
+    unless user_signed_in?
+      redirect_to action: :index
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,4 @@
+class Address < ApplicationRecord
+  belongs_to :user, optional: true
+  validates :post_code, :prefecture_code, :city, :house_number, :building_name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :nickname, :firstname, :lastname, :firstname_kana, :lastname_kana, :birth, presence: true
+  has_one :address
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_PASSWPRD_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  
   validates :nickname, :firstname, :lastname, :firstname_kana, :lastname_kana, :birth, presence: true
   has_one :address
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -9,7 +9,7 @@
         会員情報入力
       .SignUp__field--main
         .SignUp__field--main--contents
-          = form_with url: @user_path do |form|
+          = form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |form|
             = devise_error_messages!
             .FormField
               .FormField__label
@@ -44,24 +44,24 @@
                 = form.label :お名前（全角）
                 %span.Required__field--logo 必須
               .FormField__input
-                = form.text_field :name, class: 'FormField__input__name', placeholder: "例）山田"
-                = form.text_field :name, class: 'FormField__input__name', placeholder: "例）太郎"
+                = form.text_field :lastname, class: 'FormField__input__name', placeholder: "例）山田"
+                = form.text_field :firstname, class: 'FormField__input__name', placeholder: "例）太郎"
             .FormField
               .FormField__label
                 = form.label :お名前カナ（全角）
                 %span.Required__field--logo 必須
               .FormField__input
-                = form.text_field :kana, class: 'FormField__input__kana', placeholder: "例）ヤマダ"
-                = form.text_field :kana, class: 'FormField__input__kana', placeholder: "例）タロウ"
+                = form.text_field :lastname_kana, class: 'FormField__input__kana', placeholder: "例）ヤマダ"
+                = form.text_field :firstname_kana, class: 'FormField__input__kana', placeholder: "例）タロウ"
             .FormField
               .FormField__label
                 = form.label :生年月日
                 %span.Required__field--logo 必須
               .FormField__input--birthday
                 .birthday_field
-                  != sprintf(form.date_select(:birthday, prefix:'birthday',with_css_classes:'birth', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
+                  != sprintf(form.date_select(:birth,with_css_classes:'birth', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月' )+'日'
                 .clearfix
             .FormField__about
               %p1 ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
             .Actions
-            = form.submit '次へ', class: 'Actions__submit'
+            = form.submit '新規登録', class: 'Actions__submit'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
+    -# = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users
+  
+  devise_scope :users do
+    get '/users', to: redirect("/users/sign_up")
+  end
+
   root 'items#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :users, only: :show

--- a/db/migrate/20201026143423_create_addresses.rb
+++ b/db/migrate/20201026143423_create_addresses.rb
@@ -1,0 +1,13 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string :post_code,        null: false
+      t.integer :prefecture_code, null: false
+      t.string :city,             null: false
+      t.string :house_number,     null: false
+      t.string :building_name
+      t.references :user,         null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_21_183260) do
+ActiveRecord::Schema.define(version: 2020_10_26_143423) do
+
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "post_code", null: false
+    t.integer "prefecture_code", null: false
+    t.string "city", null: false
+    t.string "house_number", null: false
+    t.string "building_name"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -64,6 +76,7 @@ ActiveRecord::Schema.define(version: 2020_10_21_183260) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "addresses", "users"
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "users"

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
①ユーザー登録画面のサーバーサイドを実装し、ユーザー登録ができるように設定。
②ユーザー登録に必要なアドレステーブルを作成し、jQueryの設定を追加。

# Why 
①フリマアプリで必要なユーザーの情報を保存するため
②ユーザー登録で商品を売り買いするのに住所情報を必要とするため
③チーム開発で他のメンバーの実装で必要なため必要な部分のマージを行うため