### PR TITLE
マイページからのカード登録

### DIFF
--- a/app/views/users/_mypage_side.html.haml
+++ b/app/views/users/_mypage_side.html.haml
@@ -3,5 +3,5 @@
     %ul.Mypage__nav__list
       %li.Mypage__nav__list__li= link_to 'プロフィール', class: "List__item"
       %li.Mypage__nav__list__li= link_to '本人登録情報', class: "List__item"
-      %li.Mypage__nav__list__li= link_to 'クレジット登録/編集', class: "List__item"
+      %li.Mypage__nav__list__li= link_to 'クレジット登録/編集', pay_path, class: "List__item","data-turbolinks": false 
       %li.Mypage__nav__list__li= link_to 'ログアウト', class: "List__item"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,9 +1791,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001157:
-  version "1.0.30001157"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz#2d11aaeb239b340bc1aa730eca18a37fdb07a9ab"
-  integrity sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==
+  version "1.0.30001158"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001158.tgz#fce86d321369603c2bc855ee0e901a7f49f8310b"
+  integrity sha512-s5loVYY+yKpuVA3HyW8BarzrtJvwHReuzugQXlv1iR3LKSReoFXRm86mT6hT7PEF5RxW+XQZg+6nYjlywYzQ+g==
 
 case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.3.0"
@@ -2391,9 +2391,9 @@ cssnano@^4.1.10:
     postcss "^7.0.0"
 
 csso@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.1.0.tgz#1d31193efa99b87aa6bad6c0cef155e543d09e8b"
-  integrity sha512-h+6w/W1WqXaJA4tb1dk7r5tVbOm97MsKxzwnvOR04UQ6GILroryjMWu3pmCCtL2mLaEStQ0fZgeGiy99mo7iyg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-4.1.1.tgz#e0cb02d6eb3af1df719222048e4359efd662af13"
+  integrity sha512-Rvq+e1e0TFB8E8X+8MQjHSY6vtol45s5gxtLI/018UsAn2IBMmwNEZRM/h+HVnAJRHjasLIKKUO3uvoMM28LvA==
   dependencies:
     css-tree "^1.0.0"
 
@@ -2638,9 +2638,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.591:
-  version "1.3.595"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.595.tgz#e8a9e7c6919963419f892ea981d7b3438ccb834d"
-  integrity sha512-JpaBIhdBkF9FLG7x06ONfe0f5bxPrxRcq0X+Sc8vsCt+OPWIzxOD+qM71NEHLGbDfN9Q6hbtHRv4/dnvcOxo6g==
+  version "1.3.596"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.596.tgz#c7ed98512c7ff36ddcbfed9e54e6355335c35257"
+  integrity sha512-nLO2Wd2yU42eSoNJVQKNf89CcEGqeFZd++QsnN2XIgje1s/19AgctfjLIbPORlvcCO8sYjLwX4iUgDdusOY8Sg==
 
 elliptic@^6.5.3:
   version "6.5.3"


### PR DESCRIPTION
what
マイページからのカード登録、詳細確認、削除をできるようにする実装。

why
マイページからカードについてのことを作業できるようにするため

写真のように登録していない状態でカード登録、編集のところを押すと登録画面に飛び登録後、詳細ページに飛ぶ。
その後マイページから登録、編集のところを押すと詳細ページに飛ぶ。
そこから削除したらまた初めのように登録画面になる
<img width="1419" alt="ka-do1" src="https://user-images.githubusercontent.com/68838074/99257513-7e88e300-285a-11eb-8984-5a2969608547.png">
<img width="1407" alt="ka-do2" src="https://user-images.githubusercontent.com/68838074/99257527-85175a80-285a-11eb-81bd-593b93d7705c.png">
<img width="1394" alt="ka-do3" src="https://user-images.githubusercontent.com/68838074/99257555-8ea0c280-285a-11eb-815e-a7d56951c29d.png">

