### PR TITLE
商品出品後のedit画面での画像不具合修正、及び利益率と手数料自動計算実装

### DIFF
--- a/app/assets/javascripts/item-images.js
+++ b/app/assets/javascripts/item-images.js
@@ -25,13 +25,21 @@ $(document).on('turbolinks:load', ()=> {
 
 
   // file_fieldのnameに動的なindexをつける為の配列
-  let fileIndex = [1,2,3,4,5,6,7,8,9,10];
+  let fileIndex = [1,2,3,4,5];
   // 既に使われているindexを除外
   lastIndex = $('.js-file_group:last').data('index');
   fileIndex.splice(0, lastIndex);
 
   $('.hidden-destroy').hide();
 
+  // editページ読み込み時に画像選択エリアを非表示
+  window.onload = function() {
+    const previewcount = $('.preview').length;
+    const previewscount = $('.previews').length;
+      if (previewcount + previewscount > 4) {
+      $('#label_image').hide();
+    }
+  }
   // 画像選択でイベント発火
   $('#image-box').on('change', '.js-file', function(e) {
     const targetIndex = $(this).parent().data('index');
@@ -50,21 +58,18 @@ $(document).on('turbolinks:load', ()=> {
     } else {  // 新規画像追加の処理
       $('#image-box').append(buildImg(targetIndex, blobUrl));
 
+      
+      // fileIndexの先頭の数字を使ってinputを作る
+      $('#image-box').append(buildFileField(fileIndex[0]));
+      fileIndex.shift();
+      // 末尾の数に1足した数を追加する
+      fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
+      
+      element.htmlFor = (buildlabel(lastIndex));
+      
+      // クリックエリアを非表示
       const previewcount = $('.preview').length;
       const previewscount = $('.previews').length;
-     
-        // fileIndexの先頭の数字を使ってinputを作る
-        $('#image-box').append(buildFileField(fileIndex[0]));
-        fileIndex.shift();
-        // 末尾の数に1足した数を追加する
-        fileIndex.push(fileIndex[fileIndex.length - 1] + 1);
-        
-        element.htmlFor = (buildlabel(lastIndex));
-
-        // クリックエリアを非表示
-        if (previewcount > 4) {
-        $('#label_image').hide();
-      }
         if (previewcount + previewscount > 4) {
         $('#label_image').hide();
       }

--- a/app/assets/javascripts/item-profit.js
+++ b/app/assets/javascripts/item-profit.js
@@ -1,0 +1,28 @@
+// editページに遷移時に自動で計算
+$(document).ready(function(){
+  // 販売価格に入力された値を取得し代入→手数料と利益を計算し代入
+  let priceData = $('#item-price').val();
+  let priceProfit = Math.ceil(priceData * 0.9);
+  let priceFee = Math.ceil(priceData * 0.1);
+  // htmlメソッドで手数料と利益を書き換え
+  $('.fee__value').html(priceFee);
+  $('.profit__value').html(priceProfit);
+
+  // 販売価格入力でイベント発火
+  $('#item-price').on('change', function(){
+    // 販売価格に入力した値を取得し代入→手数料と利益を計算し代入
+    let priceData = $(this).val();
+    let priceProfit = Math.ceil(priceData * 0.9);
+    let priceFee = Math.ceil(priceData * 0.1);
+    // htmlメソッドで手数料と利益を書き換え
+    $('.fee__value').html(priceFee);
+    $('.profit__value').html(priceProfit);
+    // 不正金額時メッセージ表示
+    if (priceData < 300 || priceData > 9999999) {
+      $('.price-aleat-message').css('display','block');
+    }
+    if (priceData > 300 && priceData < 9999999) {
+      $('.price-aleat-message').css('display','none');
+    }
+  });
+});

--- a/app/assets/stylesheets/items/new.scss
+++ b/app/assets/stylesheets/items/new.scss
@@ -127,7 +127,7 @@ label{
     width: 100%;
     height: 200px;
     border: dotted 1px black;
-    .click_erea {
+    .click_area {
       width: 100%;
       display: flex;
       justify-content: center;
@@ -310,6 +310,12 @@ textarea{
   height: 48px;
   padding: 0 16px;
   width: 100%;
+}
+
+.price-aleat-message {
+  color: red;
+  display: none;
+  text-align: rigth;
 }
 
 .fee__value{

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -41,13 +41,13 @@
 
                 - if @item.persisted?
                   %label{for: "item_images_attributes_#{@item.images.count}_url",id:"label_image"}
-                    .click_erea
-                      .click_erea__content
+                    .click_area
+                      .click_area__content
                         %pクリックしてファイルをアップロード
                 - else
                   %label{for: "item_images_attributes_0_url",id:"label_image"}
-                    .click_erea
-                      .click_erea__content
+                    .click_area
+                      .click_area__content
                         %pクリックしてファイルをアップロード
 
         %hr.border
@@ -162,7 +162,9 @@
                 %span
                   ￥
                 .price__box__right
-                  = f.number_field :price, placeholder: "0"
+                  = f.number_field :price, placeholder: "0", id: "item-price"
+            .price-aleat-message
+              ¥300〜¥9,999,999で入力して下さい
             .price
               .price__fee
                 販売手数料(10%)
@@ -172,7 +174,7 @@
             .price
               .price__profit
                 販売利益
-              %span.fee__value
+              %span.profit__value
                 —
           .exhibition__bottom
             = f.submit "出品する", class: "button"


### PR DESCRIPTION
# What
①商品出品時に画像を５枚アップロードした際に、商品編集画面で６枚目の画像が選択できてしまう不具合を修正。
②商品の価格を入力すると、手数料と利益率を自動で計算して表示されるように実装した。

# Why
①画像については商品出品時に５枚選択された場合のみ、不具合が起きていたのを修正し最大５枚アップロードとするため　
②商品価格により商品の利益率と手数料を自動計算されることで、瞬時にどの程度の利益率と手数料か一目でわかるようにするため

![b7fb16eeb678d9e7ed96c39cd084f23e](https://user-images.githubusercontent.com/68668379/99897235-35fa7b00-2cdb-11eb-98ad-2da5f7845934.gif)
