### PR TITLE
商品出品、編集のテスト終了、及び編集ページへの遷移、更新、削除制限

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update,:destroy]
   before_action :set_parents, only: [:new, :create, :edit, :index]
   before_action :set_category, only: [:index]
+  before_action :item_current_user, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order("id DESC").last(5)
@@ -80,4 +81,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def item_current_user
+    unless @item.user_id == current_user.id
+      redirect_to root_path
+    end
+  end
+  
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe Item, type: :model do
 
     context '商品を保存できない場合' do
       it '画像無しでは保存できない' do
-        item = build(:item, image: nil)
+        item = build(:item)
+        item.images = []
         item.valid?
-        expect(item.errors[:images]).to include("を入力して下さい")
+        expect(item.errors[:images]).to include("を入力してください")
       end
 
       it '商品名無しで保存できない' do


### PR DESCRIPTION
# What
①商品出品編集機能のテスト実施（16項目中全て完了）。
②商品出品者以外でもブラウザにurlを直接打ち込むと、編集ページに遷移できて更新、削除もできていたので、直接urlに対象ユーザー以外がアクセスされた際は、リダイレクトでトップページに戻るようにした（ビューでは対象ユーザー以外はリンクが表示されないように以前実装済、またログインをしていない場合はログイン画面に遷移するよう以前実装済）。

※出品、編集、削除に関しての必須項目は終了となる（テスト込みで）。

# Why
①商品出品に関してテストを実施することで、思わぬバグなどを防止する必要があるため。
②ブラウザに直接urlを打ち込まれると、他の出品者の商品を編集等されてしまうための防止。

![8f1d693b11967fc28a1f125a7a7b4d69](https://user-images.githubusercontent.com/68668379/100517764-95bbbf00-31d0-11eb-8725-971f9e5f82ae.jpg)

