### PR TITLE
ルート直し

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,6 +31,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    redirect_to root_path if @item.order.present?
   end
 
   def update
@@ -79,7 +80,11 @@ class ItemsController < ApplicationController
   end
 
   def set_item
-    @item = Item.find(params[:id])
+    if Item.where(id: params[:id]).present?
+      @item = Item.find(params[:id])
+    else
+      redirect_to root_path
+    end
   end
 
   def item_current_user

--- a/app/controllers/pays_controller.rb
+++ b/app/controllers/pays_controller.rb
@@ -8,7 +8,7 @@ class PaysController < ApplicationController
   end
 
   def create #payjpとCardのデータベース作成を実施します。
-    Payjp.api_key= ENV["PAYJP_SECRET_KEY"]
+    Payjp.api_key= Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
     if params['payjp-token'].blank?
       redirect_to action: "new"
     else
@@ -31,7 +31,7 @@ class PaysController < ApplicationController
     card = Pay.where(user_id: current_user.id).first
     if card.blank?
     else
-      Payjp.api_key= ENV["PAYJP_SECRET_KEY"]
+      Payjp.api_key= Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
       card.delete
@@ -44,7 +44,7 @@ class PaysController < ApplicationController
     if card.blank?
       redirect_to action: "new" 
     else
-      Payjp.api_key= ENV["PAYJP_SECRET_KEY"]
+      Payjp.api_key= Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
       customer = Payjp::Customer.retrieve(card.customer_id)
       @default_card_information = customer.cards.retrieve(card.card_id)
     end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -6,6 +6,7 @@ class PurchasesController < ApplicationController
   
   def index
     redirect_to root_path if @item.order.present?
+    redirect_to root_path if current_user.id == @item.user_id
     @user = current_user
     @card = Pay.where(user_id: current_user.id).first
   #Payjpの秘密鍵を取得

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -14,7 +14,7 @@ class PurchasesController < ApplicationController
     #登録された情報がない場合にカード登録画面に移動
     
     else
-    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp.api_key= Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
   #Payjpから顧客情報を取得し、表示
     customer = Payjp::Customer.retrieve(@card.customer_id)
     @default_card_information = customer.cards.retrieve(@card.card_id)
@@ -26,7 +26,7 @@ class PurchasesController < ApplicationController
         @card =Pay.where(user_id: current_user.id).first
         # @item = Item.find(params[:id])
      #Payjpの秘密鍵を取得
-        Payjp.api_key= ENV["PAYJP_SECRET_KEY"]
+        Payjp.api_key= Rails.application.credentials.payjp[:PAYJP_SECRET_KEY]
      #payjp経由で支払いを実行
         charge = Payjp::Charge.create(
           amount: @item.price,


### PR DESCRIPTION
what
urlを直接打つと出品者が出品した商品の購入確認ページへいけてしまった部分の修正。
urlを直接打つと出品者が売り切れた商品の編集画面に行けてしまった部分の修正。
削除されたアイテムのurlを打った場合エラーが出てしまっていたのでトップページへ飛ぶようにした。
秘密鍵の呼び出し方を変更

why
ユーザーが行っては行けないページに行けないようにするため。