### PR TITLE
細かい直し

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,4 @@
 @import "modules/contentsHeader";
 @import "modules/address";
 @import "modules/flash";
+@import "modules/button";

--- a/app/assets/stylesheets/mixin.scss
+++ b/app/assets/stylesheets/mixin.scss
@@ -193,3 +193,27 @@
   vertical-align: top;
   background-color: #ccc;
 }
+
+@mixin sold{
+  width: 0;
+  height: 0;
+  border-width: 120px 120px 0 0;
+  border-top: 60px solid #ea352d ;
+  border-right: 60px solid transparent;
+  border-bottom: 60px solid transparent;
+  border-left: 60px solid #ea352d ;
+  display: block;
+  position: absolute;
+  top: 0;
+  z-index: 1;
+  border-style: solid;
+  left: 0;
+}
+@mixin soldInner{
+  transform: rotate(-45deg);
+  font-size: 24px;
+  margin:-35px 0px 0px -55px;
+  color: #fff;
+  letter-spacing: 2px;
+  font-weight: 600;
+}

--- a/app/assets/stylesheets/mixin.scss
+++ b/app/assets/stylesheets/mixin.scss
@@ -96,7 +96,7 @@
 @mixin center {
   display: block;
   font-size: 14px;
-  width: 328px;
+  width: 360px;
   padding: 0 10px;
   margin: 15px auto;
   letter-spacing: 1px;

--- a/app/assets/stylesheets/modules/_button.scss
+++ b/app/assets/stylesheets/modules/_button.scss
@@ -1,0 +1,28 @@
+.post__button{
+  position: fixed;
+  bottom: 32px;
+  font-size: 22px;
+  height: 160px;
+  right: 32px;
+  width: 160px;
+  z-index:100;
+}
+.new__button{
+  text-decoration: none;
+  color: inherit;
+
+}
+.button__inner{
+  border-radius: 50%;
+  background-color: #3CCACE;
+  text-align: center;
+  width: 150px;
+  height: 150px;
+  padding-top: 28px;
+}
+.inner__text{
+  font-size:35px;
+  color: rgb(255, 255, 255);
+  margin: 5px auto 0px;
+  margin-top: 25px;
+}

--- a/app/assets/stylesheets/modules/_detail.scss
+++ b/app/assets/stylesheets/modules/_detail.scss
@@ -42,7 +42,7 @@
     margin: 0 auto;
   }
   &__right{
-    width: 700px;
+    width: 51%;
     margin: 0 auto;
   }
   &__box{
@@ -74,7 +74,7 @@
 .product__box__body ul li img{
   object-fit: cover;
   height: 346px;
-  
+  width: 560px;
 }
 .product__box__body ul li ul{
   display: flex;
@@ -244,6 +244,7 @@ td a{
   font-weight: bold;
   font-size: 22px;
   position: relative;
+  text-align: center;
 }
 
 .product__img{
@@ -260,18 +261,21 @@ td a{
 }
 
 .product__lists{
-  width: 780px;
+  width: 81%;
   margin: 50px auto 0 auto;
   @include display;
-  justify-content: space-around;
+  overflow: scroll;
   &__list{
-    width: 220px;
     display: inline-block;
-    float: left;
+    position: relative;
+    width:100%;
+    height:100%;
     &__item__name {
       background-color: white;
       color: #333;
       padding: 16px;
+      height:95px;
+      
     }
   }
 }
@@ -317,7 +321,6 @@ td a{
     border-radius: 100px;
   }
 }
-
 .items-box_photo__sold{
   left:0;
   width: 0;
@@ -340,6 +343,12 @@ td a{
     letter-spacing: 2px;
     font-weight: 600;
   }
+}
+.product-box_photo__solds{
+  @include sold;
+}
+.product-box_photo__sold__inners{
+  @include soldInner;
 }
 .btns {
   font-size: 14px;

--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -1,18 +1,4 @@
-@media screen and (max-width: 300px) {
-  .post__button{
-    right: -14px;
-    bottom: -14px;
-  }
-  .button__inner{
-    padding-top: 15px;
-    height: 80px;
-    width: 80px;
-  }
-  .inner__text{
-    font-size:22px;
-  }
-}  
-.main{
+  .main{
   background: #f8f8f8;
   max-width: 100%;
 }
@@ -312,53 +298,8 @@
   height: 100%;
 }
 .items-box_photo__solds{
-  width: 0;
-  height: 0;
-  border-width: 120px 120px 0 0;
-  border-top: 60px solid #ea352d ;
-  border-right: 60px solid transparent;
-  border-bottom: 60px solid transparent;
-  border-left: 60px solid #ea352d ;
-  display: block;
-  position: absolute;
-  top: 0;
-  z-index: 1;
-  border-style: solid;
+  @include sold;
 }
 .items-box_photo__sold__inners{
-  transform: rotate(-45deg);
-  font-size: 24px;
-  margin:-35px 0px 0px -55px;
-  color: #fff;
-  letter-spacing: 2px;
-  font-weight: 600;
-}
-
-.post__button{
-  position: fixed;
-  bottom: 32px;
-  font-size: 22px;
-  height: 160px;
-  right: 32px;
-  width: 160px;
-  z-index:100;
-}
-.new__button{
-  text-decoration: none;
-  color: inherit;
-
-}
-.button__inner{
-  border-radius: 50%;
-  background-color: #3CCACE;
-  text-align: center;
-  width: 150px;
-  height: 150px;
-  padding-top: 28px;
-}
-.inner__text{
-  font-size:35px;
-  color: rgb(255, 255, 255);
-  margin: 5px auto 0px;
-  margin-top: 25px;
+  @include soldInner;
 }

--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -1,9 +1,24 @@
+@media screen and (max-width: 300px) {
+  .post__button{
+    right: -14px;
+    bottom: -14px;
+  }
+  .button__inner{
+    padding-top: 15px;
+    height: 80px;
+    width: 80px;
+  }
+  .inner__text{
+    font-size:22px;
+  }
+}  
 .main{
   background: #f8f8f8;
+  max-width: 100%;
 }
 
 .mainArea{
-  width: 100%;
+  // width: 100%;
   height: 560px;
   background-image: image-url("public/images/bg-mainVisual-pict_pc.jpg");
   // background-image: url('public/images/bg-mainVisual-pict_pc.jpg');
@@ -245,26 +260,24 @@
   margin-top: 50px;
 }
 .item__lists{
-  width: 780px;
+  width: 80%;
   margin: 50px auto 0 auto;
   @include display;
-  justify-content: space-around;
+  overflow: scroll;
 }
 
 .item__list{
-  width: 220px;
   display: inline-block;
-  float: left;
   position: relative;
-
+  width:100%;
+  height:100%;
   &__body{
     @include background-color;
     color: #333;
-    padding: 16px;
+    padding: 12px;
     height:95px;
   }
 }
-
 .item__box__name{
   overflow: hidden;
   line-height: 1.5;
@@ -319,4 +332,33 @@
   color: #fff;
   letter-spacing: 2px;
   font-weight: 600;
+}
+
+.post__button{
+  position: fixed;
+  bottom: 32px;
+  font-size: 22px;
+  height: 160px;
+  right: 32px;
+  width: 160px;
+  z-index:100;
+}
+.new__button{
+  text-decoration: none;
+  color: inherit;
+
+}
+.button__inner{
+  border-radius: 50%;
+  background-color: #3CCACE;
+  text-align: center;
+  width: 150px;
+  height: 150px;
+  padding-top: 28px;
+}
+.inner__text{
+  font-size:35px;
+  color: rgb(255, 255, 255);
+  margin: 5px auto 0px;
+  margin-top: 25px;
 }

--- a/app/assets/stylesheets/pays/_show.scss
+++ b/app/assets/stylesheets/pays/_show.scss
@@ -1,9 +1,19 @@
 .resistration__card {
+  background-color: white;
   font-size: 30px;
-  margin-top: 35px;
-
+  height: 80%;
+  width: 80%;
+  padding-top: 35px;
+  text-align: center;
+  margin: auto;
+  padding-bottom: 20%;
   &__detail{
-    font-size:20px;
-    margin-top:25px;
+    font-size: 20px;
+    margin-top: 2%;
+  }
+  &__delete{
+    margin-top: 2%;
+    margin-bottom: 1%;
   }
 }
+

--- a/app/assets/stylesheets/purchases/_create.scss
+++ b/app/assets/stylesheets/purchases/_create.scss
@@ -2,7 +2,7 @@
    background-color:#3CCACE ;
    width:100%;
    height:100px;
-   font-size:50px;
+   font-size:30px;
    text-align: center;
    padding-top:20px;
 }

--- a/app/assets/stylesheets/purchases/_index.scss
+++ b/app/assets/stylesheets/purchases/_index.scss
@@ -1,6 +1,6 @@
 .allscreens{ 
   height: 100vh;
-  width: 44%;
+  max-width: 700px;
   margin: auto;
   
     .all{
@@ -10,13 +10,12 @@
 
       .Header {
         height: 128px;
-        width:300px;
+        width:360px;
         background-color:white;
         font-size:25px ;
         padding: 60px;
         text-align: center ;
-        margin-left: 160px;
-
+        margin: 0 auto;
       }
 
       .shopping{
@@ -85,9 +84,9 @@
         font-size: 14px;
         display: block;
         height: 48px;
-        width: 328px;
+        width: 360px;
         padding: 0 30px;
-        margin: 8px auto;
+        margin: 0px auto;
         line-height: 40px;
         letter-spacing: 1px;
         text-align: center;

--- a/app/assets/stylesheets/users/_show.scss
+++ b/app/assets/stylesheets/users/_show.scss
@@ -51,6 +51,9 @@
           &__item {
             padding: 10px 0 0 0;
             word-break: break-all;
+            &__address {
+              margin-top:10px;
+            }
           }
         }
       }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,11 +23,12 @@ class ItemsController < ApplicationController
     else
       render :new
     end
-
+ 
   end
   
   def show
     @items = Item.includes(:images).order('created_at DESC')
+    @items = Item.order("id DESC").limit(5)
   end
 
   def edit

--- a/app/views/items/_button.html.haml
+++ b/app/views/items/_button.html.haml
@@ -1,0 +1,5 @@
+.post__button
+  %a{ href: "#", class: 'new__button' }
+    .button__inner
+      .inner__text
+        = link_to "出品",new_item_path

--- a/app/views/items/_detail.html.haml
+++ b/app/views/items/_detail.html.haml
@@ -31,12 +31,11 @@
           .product__box__body
             %ul 
               %li 
-                .pic__sold
-                  - @item.images.each do |image| 
-                    = image_tag image.url.url
-                      -if @item.order.present?
-                  .items-box_photo__sold
-                    .items-box_photo__sold__inner SOLD
+                - @item.images.each do |image| 
+                  = image_tag image.url.url
+                  -if @item.order.present?
+                    .items-box_photo__sold
+                      .items-box_photo__sold__inner SOLD
           .product__box__price
             %span
               = "¥"

--- a/app/views/items/_detail.html.haml
+++ b/app/views/items/_detail.html.haml
@@ -127,7 +127,7 @@
           - else 
             .purchase__confirmation
               .purchase__confirmation__sell
-                = link_to "新規登録して購入する",new_user_registration_path
+                = link_to "新規登録orログイン",new_user_session_path
         .comment__box
           - if @item.order.present?
           -else

--- a/app/views/items/_detail.html.haml
+++ b/app/views/items/_detail.html.haml
@@ -1,4 +1,4 @@
-= render 'items/header'
+= render "items/index_header"
 %nav.category__order
   %ul 
     %li 
@@ -31,11 +31,12 @@
           .product__box__body
             %ul 
               %li 
-                - @item.images.each do |image| 
-                  = image_tag image.url.url,size: "560x346"
-                  -if @item.order.present?
-                    .items-box_photo__sold
-                      .items-box_photo__sold__inner SOLD
+                .pic__sold
+                  - @item.images.each do |image| 
+                    = image_tag image.url.url
+                      -if @item.order.present?
+                  .items-box_photo__sold
+                    .items-box_photo__sold__inner SOLD
           .product__box__price
             %span
               = "¥"
@@ -153,21 +154,25 @@
             = link_to '後ろの商品', '#'
             %span
             %i.fa.fa-angle-right
-        .item__related
-          = link_to '新着投稿商品', '#'
-        .product__lists
-          - @items.each do |item|
-            .product__lists__list
-              = link_to item_path(item.id) do
-                %figure.product__img
-                  = image_tag item.images[0].url.url, size: "220x150", class: "images"
-              .product__lists__list__item__name
-                %h3.item--name 
-                  = item.name
-                .item--detail
-                  %ul 
-                    %li 
-                      = item.price
-                      円
-                    %i.fa.fa-star 1
-                    %p (税込）
+    .products__box
+      .item__related
+        = link_to '新着商品', '#'
+      .product__lists
+        - @items.each do |item|
+          .product__lists__list
+            = link_to item_path(item.id) do
+              %figure.product__img
+                = image_tag item.images[0].url.url, size: "220x150", class: "images"
+            .product__lists__list__item__name
+              %h3.item--name 
+                = item.name
+              .item--detail
+                %ul 
+                  %li 
+                    = item.price
+                    円
+                  %i.fa.fa-star 1
+                  %p (税込）
+                -if item.order.present?
+                  .product-box_photo__solds
+                    .product-box_photo__sold__inners SOLD

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -182,11 +182,9 @@
                 —
           .exhibition__bottom
             = f.submit "出品する", class: "button"
-            %button{:type => "submit", :class => "buttonB"}
-              下書きに保存
             %a{ href: '#'}
               .back__home
-                もどる
+                = link_to "もどる",root_path
           .caution
             %p.caution__content 
               %p.caution__sentence

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -1,3 +1,4 @@
+= render "items/button"
 .main
   %section.mainArea
     .content
@@ -154,8 +155,3 @@
               -if man.order.present?
                 .items-box_photo__solds
                   .items-box_photo__sold__inners SOLD
-      .post__button
-        %a{ href: "#", class: 'new__button' }
-          .button__inner
-            .inner__text
-              = link_to "出品",new_item_path

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -97,7 +97,7 @@
       .itemHead
         %a{ href: '#'}
           %h3.item__title
-            新規投稿商品
+            新着商品
       .item__lists
         - @items.each do |item|
           .item__list
@@ -117,7 +117,7 @@
       .itemHead
         %a{ href: '#'}
           %h3.item__title
-            レディース・新着
+            新着・レディース
       .item__lists
         - @ladies.each do |lady|
           .item__list
@@ -137,7 +137,7 @@
       .itemHead
         %a{ href: '#'}
           %h3.item__title
-            メンズ・新着
+            新着・メンズ
       .item__lists
         - @mens.each do |man|
           .item__list
@@ -154,3 +154,8 @@
               -if man.order.present?
                 .items-box_photo__solds
                   .items-box_photo__sold__inners SOLD
+      .post__button
+        %a{ href: "#", class: 'new__button' }
+          .button__inner
+            .inner__text
+              = link_to "出品",new_item_path

--- a/app/views/pays/show.html.haml
+++ b/app/views/pays/show.html.haml
@@ -1,3 +1,4 @@
+= render "items/index_header"
 .resistration__card 
   登録クレジットカード情報
   .resistration__card__detail
@@ -6,7 +7,7 @@
     - exp_month = @default_card_information.exp_month.to_s
     - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
     = exp_month + " / " + exp_year
-    = form_tag(delete_pays_path, method: :post, id: 'charge-form',  name: "inputForm") do
+    = form_tag(delete_pays_path, method: :post, id: 'charge-form',  name: "inputForm", class: "resistration__card__delete") do
       %input{ type: "hidden", name: "card_id", value: "" }
       %button 削除する
     = link_to "トップページへ戻る",root_path

--- a/app/views/users/_mypage_main.html.haml
+++ b/app/views/users/_mypage_main.html.haml
@@ -20,3 +20,12 @@
         e-mail 
         %p.Main__information__group__item 
           = current_user.email
+      %li.Main__information__group 
+        住所
+        %p.Main__information__group__item
+          〒
+          =current_user.address.post_code
+          %br
+          =current_user.address.city
+          =current_user.address.house_number
+          =current_user.address.building_name

--- a/app/views/users/_mypage_side.html.haml
+++ b/app/views/users/_mypage_side.html.haml
@@ -1,7 +1,6 @@
 .Mypage-side
   %nav.Mypage__nav
     %ul.Mypage__nav__list
-      %li.Mypage__nav__list__li= link_to 'プロフィール', class: "List__item"
       %li.Mypage__nav__list__li= link_to '本人登録情報', class: "List__item"
       %li.Mypage__nav__list__li= link_to 'クレジット登録/編集', pay_path, class: "List__item"
       %li.Mypage__nav__list__li= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "List__item"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,5 @@
+= render "items/index_header"
+= render "items/button"
 .Container
   = render "mypage_side"
   = render "mypage_main"


### PR DESCRIPTION
what
新着商品の名称を合わせる
画面新着商品のビュー崩れ
マイページの「プロフィール」削除。住所の表示付け足し。
マイページよりトップページへ行けるヘッダーの追加
出品、編集ページにはヘッダーをつけないので、現状かざりの戻るボタンを設定して有効にする
下書きのページは実装しないので削除する
詳細ページのヘッダー追加して現状のロゴを削除
未ログインユーザーが詳細ページより購入しようとした際に「新規登録して購入する」を押した後、新規登録画面に遷移してしまうのを、ログインか新規登録を選べる画面に遷移させる。
商品購入後の詳細ページ下の新着商品に「SOLD」をつける
商品購入ページの画面縮小時の全体のビュー崩れ
特定のページへのカメラマーク追加（出品ページへの）

why
細かいところの修正をしアプリとして成り立たせるため。
<img width="1334" alt="１" src="https://user-images.githubusercontent.com/68838074/101585008-3f494e80-3a22-11eb-9eb7-d430f78a3fc6.png">
<img width="1416" alt="２" src="https://user-images.githubusercontent.com/68838074/101585020-45d7c600-3a22-11eb-8605-2a342842ece7.png">
![7d0091dd377cb944f6ae26c61b0c63f4](https://user-images.githubusercontent.com/68838074/101585034-4ec89780-3a22-11eb-80ee-263ab044a32d.gif)
![2bdf991f27731203da8b403da04abccf](https://user-images.githubusercontent.com/68838074/101585058-5b4cf000-3a22-11eb-8935-f1d0f8a71154.gif)
![0bb28b80fbe5f22e9a4047cc55daac84](https://user-images.githubusercontent.com/68838074/101585113-74ee3780-3a22-11eb-8a40-e9e6efd810e0.gif)
<img width="1096" alt="4" src="https://user-images.githubusercontent.com/68838074/101585231-b5e64c00-3a22-11eb-93d8-5d8fc798d61d.png">






