### PR TITLE
ビュー直し（トップページ、詳細画面の商品）

### DIFF
--- a/app/assets/stylesheets/modules/_detail.scss
+++ b/app/assets/stylesheets/modules/_detail.scss
@@ -265,7 +265,7 @@ td a{
 .links li:last-child {
   float:right;
 }
-.item__related a{
+.item__related {
   display: block;
   margin: 24px 0 8px;
   color: #3CCACE;
@@ -297,7 +297,7 @@ td a{
   &__list{
     display: inline-block;
     position: relative;
-    width:100%;
+    width:220px;
     height:100%;
     &__item__name {
       background-color: white;
@@ -347,6 +347,7 @@ td a{
     text-align: center;
     font-size: 20px;
     border-radius: 100px;
+    margin:auto;
   }
 }
 .items-box_photo__sold{

--- a/app/assets/stylesheets/modules/_main.scss
+++ b/app/assets/stylesheets/modules/_main.scss
@@ -236,14 +236,13 @@
 .itemHead{
   text-align: center;
 }
-.itemHead a{
-  font-size: 24px;
-  text-decoration: none;
-  color: #3CCACE;
-}
+
 .item__title{
   font-weight: bold;
   margin-top: 50px;
+  font-size: 24px;
+  text-decoration: none;
+  color: #3CCACE;
 }
 .item__lists{
   width: 80%;
@@ -255,7 +254,7 @@
 .item__list{
   display: inline-block;
   position: relative;
-  width:100%;
+  width:220px;
   height:100%;
   &__body{
     @include background-color;

--- a/app/views/items/_detail.html.haml
+++ b/app/views/items/_detail.html.haml
@@ -181,7 +181,7 @@
             %i.fa.fa-angle-right
     .products__box
       .item__related
-        = link_to '新着商品', '#'
+        新着商品
       .product__lists
         - @items.each do |item|
           .product__lists__list

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -96,9 +96,8 @@
       ピックアップ
     .itemBox
       .itemHead
-        %a{ href: '#'}
-          %h3.item__title
-            新着商品
+        %h3.item__title
+          新着商品
       .item__lists
         - @items.each do |item|
           .item__list
@@ -116,9 +115,8 @@
                 .items-box_photo__solds
                   .items-box_photo__sold__inners SOLD
       .itemHead
-        %a{ href: '#'}
-          %h3.item__title
-            新着・レディース
+        %h3.item__title
+          新着・レディース
       .item__lists
         - @ladies.each do |lady|
           .item__list
@@ -136,9 +134,8 @@
                 .items-box_photo__solds
                   .items-box_photo__sold__inners SOLD
       .itemHead
-        %a{ href: '#'}
-          %h3.item__title
-            新着・メンズ
+        %h3.item__title
+          新着・メンズ
       .item__lists
         - @mens.each do |man|
           .item__list


### PR DESCRIPTION

![7d964ec86fd0af78ea8cf5c1bb5733f2](https://user-images.githubusercontent.com/68838074/101973184-62ba0680-3c79-11eb-9953-21a6a4419bbc.gif)
what
トップページと詳細画面の新着商品などが５枚以下の時ビューが崩れていたので修正
新着商品、メンズ新着、レディース新着のクリックをできないようにする

why
アプリとしておかしいビューになっていたのを直すため。